### PR TITLE
Add 'ext-dom' to CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        extensions: mbstring, zip
+        extensions: dom, mbstring, zip
         tools: prestissimo
         coverage: pcov
 


### PR DESCRIPTION
This should fix the CI by installing the PHP DOM extension... I have no idea what changed for this to start breaking though. 🤔