### PR TITLE
Fix README docs link leading to 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository contains the Pest Plugin API.
 
 > If you want to start testing your application with Pest, visit the main **[Pest Repository](https://github.com/pestphp/pest)**.
 
-- Explore the docs: **[pestphp.com/docs/guides/plugins/ »](https://pestphp.com/docs/guides/plugins/)**
+- Explore the docs: **[pestphp.com/docs/plugins/creating-plugins/ »](https://pestphp.com/docs/plugins/creating-plugins)**
 - Follow us on Twitter: **[@pestphp »](https://twitter.com/pestphp)**
 - Join us on the Discord Server: **[discord.gg/bMAJv82 »](https://discord.gg/bMAJv82)**
 


### PR DESCRIPTION
Heya! 👋

This PR fixed the docs link in the `README` pointing to a 404 page, guessing it's an older guide that no longer exists, so I updated the link to point to **Creating Plugins** instead. 🙂