### PR TITLE
Update composer/composer to ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "composer/composer": "^1.10.23|^2.0",
+        "composer/composer": "^1.10.23|^2.1.9",
         "pestphp/pest-dev-tools": "dev-master",
         "pestphp/pest": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "composer/composer": "^1.10.19",
+        "composer/composer": "^2",
         "pestphp/pest-dev-tools": "dev-master",
         "pestphp/pest": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "composer/composer": "^2",
+        "composer/composer": "^1.10|^2.0",
         "pestphp/pest-dev-tools": "dev-master",
         "pestphp/pest": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "composer/composer": "^1.10|^2.0",
+        "composer/composer": "^1.10.23|^2.0",
         "pestphp/pest-dev-tools": "dev-master",
         "pestphp/pest": "^1.0"
     },

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -23,8 +23,9 @@ final class DumpCommand extends BaseCommand
     {
         $composer = $this->getComposer();
 
-        if ($composer == null)
+        if ($composer == null) {
             throw new \RuntimeException('Could not get Composer\Composer instance.');
+        }
 
         $vendorDirectory = $composer->getConfig()->get('vendor-dir');
         $plugins         = [];

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -23,7 +23,7 @@ final class DumpCommand extends BaseCommand
     {
         $composer = $this->getComposer();
 
-        if ($composer == null) {
+        if ($composer === null) {
             throw new \RuntimeException('Could not get Composer\Composer instance.');
         }
 

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -21,12 +21,17 @@ final class DumpCommand extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $vendorDirectory = $this->getComposer()->getConfig()->get('vendor-dir');
+        $composer = $this->getComposer();
+
+        if ($composer == null)
+            throw new \RuntimeException('Could not get Composer\Composer instance.');
+
+        $vendorDirectory = $composer->getConfig()->get('vendor-dir');
         $plugins         = [];
 
-        $packages = $this->getComposer()->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
+        $packages = $composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages();
 
-        $packages[] = $this->getComposer()->getPackage();
+        $packages[] = $composer->getPackage();
 
         /** @var \Composer\Package\PackageInterface $package */
         foreach ($packages as $package) {


### PR DESCRIPTION
This commit updates composer/composer to ^2, more specifically allows for updating to 2.1.9. which in turn includes fix for the following incident
https://nvd.nist.gov/vuln/detail/CVE-2021-41116