### PR TITLE
Load pest-plugin.json from where vendor is located

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -58,7 +58,7 @@ final class Loader
     private static function getPluginInstances(): array
     {
         if (! self::$loaded) {
-            $cachedPlugins = sprintf('%s/vendor/pest-plugins.json', getcwd());
+            $cachedPlugins = sprintf('%s/../pest-plugins.json', $GLOBALS['_composer_bin_dir']);
             $container = Container::getInstance();
 
             if (! file_exists($cachedPlugins)) {


### PR DESCRIPTION
When using Composer's `vendor-dir` configuration to customize the location of vendor, Pest ends up dumping the plugin JSON file in the right place, but doesn't read it from the right place, which means no plugins are loaded.

This uses Composer's definition of where the autoloader folder is located instead, so it will always match where the file was written.