### PR TITLE
fix: resolve undefined global

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "type": "composer-plugin",
     "require": {
         "php": "^8.1",
-        "composer-plugin-api": "^2.0.0"
+        "composer-plugin-api": "^2.0.0",
+        "composer-runtime-api": "^2.2.2"
     },
     "conflict": {
         "pestphp/pest": "<2.2.3"

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -58,7 +58,10 @@ final class Loader
     private static function getPluginInstances(): array
     {
         if (! self::$loaded) {
-            $cachedPlugins = sprintf('%s/../pest-plugins.json', $GLOBALS['_composer_bin_dir']);
+            $cachedPlugins = sprintf(
+                '%s/../pest-plugins.json',
+                $GLOBALS['_composer_bin_dir'] ?? getcwd().'/vendor/bin',
+            );
             $container = Container::getInstance();
 
             if (! file_exists($cachedPlugins)) {


### PR DESCRIPTION
@nunomaduro, I've required `composer-runtime-api:^2.2.2` as recommended by Composer, but not sure if that's something we want to do. 🤷🏻

This falls back to the previous behavior if the `_composer_bin_dir` global is undefined.

Closes pestphp/pest#925