### PR TITLE
remove include from neon file

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon
-    - vendor/ergebnis/phpstan-rules/rules.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
 parameters:

--- a/src/Commands/DumpCommand.php
+++ b/src/Commands/DumpCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
-final class DumpCommand extends BaseCommand // @phpstan-ignore-line
+final class DumpCommand extends BaseCommand
 {
     protected function configure(): void
     {


### PR DESCRIPTION
Related to [this commit](https://github.com/pestphp/pest-dev-tools/commit/57739901f273a44fb004d32118c0eff5b073a0f4) which removed the `ergebnis/phpstan-rules` package. 

The base neon file for this package still includes it as an included file, which means when you run Larastan, you get:

> ergebnis/phpstan-rules/rules.neon' is missing or is not readable.

People will still need to remove it from their own applications, but this will fix it for any new forks.

