### PR TITLE
Fix locating pest-plugins.json

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -60,7 +60,7 @@ final class Loader
         if (! self::$loaded) {
             $cachedPlugins = sprintf(
                 '%s/../pest-plugins.json',
-                $GLOBALS['_composer_bin_dir'] ?? getcwd().'/vendor/bin',
+                $GLOBALS['_composer_bin_dir'] ?? __DIR__.'/../../../../vendor/bin',
             );
             $container = Container::getInstance();
 


### PR DESCRIPTION
Fix fallback path being based on cwd instead of `__DIR__` which is more reliable.