### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: 8.4
         tools: composer:v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: ${{ matrix.php }}
         tools: composer:v2


### PR DESCRIPTION
Pins every `uses:` reference in this repo's GitHub Actions workflows to a
commit SHA, preserving the original tag as an inline comment so Dependabot can
keep bumping it.

Rewrites:

  - `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (in `.github/workflows/static.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/static.yml`)
  - `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (in `.github/workflows/tests.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/tests.yml`)

This mitigates supply-chain risk from compromised action tag/branch refs and
makes future Dependabot PRs update the SHA in place (rather than only bumping
tags).